### PR TITLE
jax-jumpy 0.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,32 +10,41 @@ source:
   sha256: 8ffe4e7609461d13decc97269ff48a3ee8d7570c96cbcc82487f893a3dd65093
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
   number: 0
+  skip: True  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
 
 requirements:
   host:
-    - hatchling >=1.4.0
+    - hatchling 1.8.0
     - pip
-    - python >=3.7
+    - python
+    - numpy
   run:
     - numpy >=1.18.0
-    - python >=3.7
+    - python
+  run_constrained:
+    - jax >=0.3.24
+    - jaxlib >=0.3.24
 
 test:
   imports:
     - jumpy
-  commands:
-    - pip check
   requires:
     - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/Farama-Foundation/Jumpy
   summary: Common backend for JAX or numpy.
   license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE
+  description: |
+    Jumpy is a common backend for JAX or numpy.
+  doc_url: https://github.com/Farama-Foundation/Jumpy
+  dev_url: https://github.com/Farama-Foundation/Jumpy
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - pip
     - python
     - numpy
+    - wheel
   run:
     - numpy >=1.18.0
     - python


### PR DESCRIPTION
Changelog: https://github.com/Farama-Foundation/Jumpy/releases
License: https://github.com/Farama-Foundation/Jumpy/blob/0.2.0/LICENSE
Requirements: https://github.com/Farama-Foundation/Jumpy/blob/0.2.0/pyproject.toml

Actions:
1. Remove noarch, skip py<37
2. Add --no-deps
3. Fix hatchling pinning in host
4. Fix python pinnings
5. Add numpy to host for correct pinnings in run
6. Add wheel
7. Add run_constrained: jax >=0.3.24, jaxlib >=0.3.24, see https://github.com/Farama-Foundation/Jumpy/blob/13ca87b84af21bb7314df6303d266c385315b67e/pyproject.toml#L37-L39
8. Add license_family
9. Add description
10. Add doc and dev urls