### PR TITLE
Update to 1.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,25 +1,24 @@
 {% set name = "jax-jumpy" %}
-{% set version = "0.2.0" %}
+{% set version = "1.0.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/jax_jumpy-{{ version }}.tar.gz
-  sha256: 8ffe4e7609461d13decc97269ff48a3ee8d7570c96cbcc82487f893a3dd65093
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 195fb955cc4c2b7f0b1453e3cb1fb1c414a51a407ffac7a51e69a73cb30d59ad
 
 build:
   number: 0
   skip: True  # [py<37]
-  script: {{ PYTHON }} -m pip install . -vv --no-deps
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
-    - hatchling 1.8.0
+    - setuptools >=61.0.0
     - pip
     - python
-    - numpy
     - wheel
   run:
     - numpy >=1.18.0


### PR DESCRIPTION
Update to 1.0.0. Required by https://github.com/AnacondaRecipes/gymnasium-feedstock/pull/2.

Upstream diff: https://github.com/Farama-Foundation/Jumpy/compare/0.2.0..1.0.0